### PR TITLE
Require debug information for libabigail predictor

### DIFF
--- a/docs/getting_started/user-guide.rst
+++ b/docs/getting_started/user-guide.rst
@@ -81,6 +81,10 @@ Also to export a custom set of directories for separate debug files (see :ref:`d
 
 The suffix ``1`` indicates the original library and ``2`` is for the comparison library.
 
+libabigail can work both with and without debugging information. To require libabigail to use
+debugging information, you can set the environment variable ``LIBABIGAIL_REQUIRE_DEBUGINFO``.
+This has the same effect as passing ``--fail-no-debug-info`` directly to ``abidiff``.
+
 Smeagle
 -------
 

--- a/spliced/predict/libabigail.py
+++ b/spliced/predict/libabigail.py
@@ -154,10 +154,11 @@ class LibabigailPrediction(Prediction):
         if debug2:
             debug2 = f"--debug-info-dir2 {debug2}"
 
-        command = "%s %s %s %s %s" % (
+        command = "%s %s %s %s %s %s" % (
             self.abidiff,
             debug1,
             debug2,
+            "--fail-no-debug-info"
             original_lib,
             replace_lib,
         )

--- a/spliced/predict/libabigail.py
+++ b/spliced/predict/libabigail.py
@@ -158,7 +158,7 @@ class LibabigailPrediction(Prediction):
             self.abidiff,
             debug1,
             debug2,
-            "--fail-no-debug-info"
+            "--fail-no-debug-info",
             original_lib,
             replace_lib,
         )

--- a/spliced/predict/libabigail.py
+++ b/spliced/predict/libabigail.py
@@ -154,11 +154,15 @@ class LibabigailPrediction(Prediction):
         if debug2:
             debug2 = f"--debug-info-dir2 {debug2}"
 
+        require_debug = os.environ.get("LIBABIGAIL_REQUIRE_DEBUGINFO", "")
+        if require_debug:
+            require_debug = "--fail-no-debug-info"
+
         command = "%s %s %s %s %s %s" % (
             self.abidiff,
             debug1,
             debug2,
-            "--fail-no-debug-info",
+            require_debug,
             original_lib,
             replace_lib,
         )


### PR DESCRIPTION
I've hard-coded this because I'm not sure if it would be useful to make it a general option for the predictor. What do you think?